### PR TITLE
Allows special characters

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -41,7 +41,7 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
      */
     private function saveComposerPlugAndPlayFile(array $data)
     {
-        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
 
         file_put_contents(self::FILENAME, $json);
     }


### PR DESCRIPTION
If `composer.json` has special characters, it is converted into escaped Unicode character. Change to maintain the real character using Unicode multibyte.