### PR TITLE
Relative path instead of absolute path in package symlink

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  tests:
+
+    name: Unit Tests
 
     runs-on: ubuntu-latest
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -57,7 +57,7 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
     {
         return [
             'type' => 'path',
-            'url' => realpath(dirname($package)),
+            'url' => './' . dirname($package),
             'symlink' => true
         ];
     }

--- a/tests/Fixtures/Plugin/packages/dex/fake/composer.json
+++ b/tests/Fixtures/Plugin/packages/dex/fake/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "dex/fake"
+}

--- a/tests/Unit/Composer/FactoryTest.php
+++ b/tests/Unit/Composer/FactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Dex\Composer\PlugAndPlay\Tests\Unit\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Dex\Composer\PlugAndPlay\Composer\Factory;
+use Dex\Composer\PlugAndPlay\PlugAndPlayInterface;
+use Dex\Composer\PlugAndPlay\Tests\TestCase;
+
+class FactoryTest extends TestCase
+{
+    const PATH = __DIR__ . '/../../Fixtures/Plugin/';
+
+    private $cwd;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cwd = getcwd();
+
+        chdir(self::PATH);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        chdir($this->cwd);
+        unlink(self::PATH . PlugAndPlayInterface::FILENAME);
+    }
+
+    public function testFactory()
+    {
+        $composerPlugAndPlayFile = self::PATH . PlugAndPlayInterface::FILENAME;
+
+        $io = $this->createMock(IOInterface::class);
+
+        $factory = new Factory();
+
+        $composer = $factory->createComposer($io, null, false, self::PATH);
+
+        $json = json_encode([
+            'require' => [
+                'dex/composer-plug-and-play' => '*',
+                'dex/fake' => '*',
+            ],
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => '../../../',
+                ],
+                [
+                    'type' => 'path',
+                    'url' => './packages/dex/fake',
+                    'symlink' => true,
+                ],
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
+
+        $this->assertInstanceOf(Composer::class, $composer);
+        $this->assertFileExists($composerPlugAndPlayFile);
+        $this->assertStringEqualsFile($composerPlugAndPlayFile, $json);
+    }
+}


### PR DESCRIPTION
Instead to use absolute path `/home/dex/project/packages/dex/fake` use relative path `./packages/dex/fake` to ensure that when the project folder will moved to another directory the symlink continues working.