### PR TITLE
Add real support to Composer 2.3

### DIFF
--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -54,6 +54,28 @@ trait ComposerCreator
     }
 
     /**
+     * Retrieves the default Composer\Composer instance or throws
+     *
+     * Use this instead of getComposer if you absolutely need an instance
+     *
+     * @see Application::getPluginCommands()
+     *
+     * @param bool|null $disablePlugins If null, reads --no-plugins as default
+     * @param bool|null $disableScripts If null, reads --no-scripts as default
+     * @throws \RuntimeException
+     */
+    public function requireComposer(bool $disablePlugins = null, bool $disableScripts = null): Composer
+    {
+        // It's needed that Composer will be reseted because
+        // Application::getPluginCommands() creates a Composer instance without
+        // plug and play capabilities.
+
+        $this->resetComposer();
+
+        return Factory::create($this->getApplication()->getIO());
+    }
+
+    /**
      * Check if plug and play plugin is running.
      *
      * @param InputInterface  $input

--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -13,11 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 trait ComposerCreator
 {
     /**
-     * @var Composer
-     */
-    protected $composer;
-
-    /**
      * @var bool
      */
     protected $usePlugAndPlay = false;


### PR DESCRIPTION
It's needed that Composer will be reseted because Application::getPluginCommands() creates a Composer instance without plug and play capabilities.