### PR TITLE
Create a bin file for easy debugging

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,9 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Composer\Console\Application;
+
+$application = new Application();
+$application->run();


### PR DESCRIPTION
It's not possible to use Xdebug with the actual Composer binary, so this binary adds this possibility.