### PR TITLE
Add `plug-and-play` command

### DIFF
--- a/src/Commands/PlugAndPlayCommand.php
+++ b/src/Commands/PlugAndPlayCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Dex\Composer\PlugAndPlay\Commands;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PlugAndPlayCommand extends BaseCommand
+{
+    use CommandNaming, ComposerCreator;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->naming('plug-and-play');
+        $this->setDescription('Installs plug and play dependencies together project dependencies.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>You are using Composer Plug and Play Plugin.</info>');
+
+        if ($input->getOption('plug-and-play-pretend')) {
+            return 0;
+        }
+
+        $locker = $this->getComposer()->getLocker();
+        $runInstall = $locker->isLocked() && $locker->isFresh();
+
+        $command = $runInstall
+            ? new InstallCommand()
+            : new UpdateCommand();
+
+        $command->setApplication($this->getApplication());
+        $command->initialize($input, $output);
+
+        return $command->run($input, $output);
+    }
+}

--- a/src/PlugAndPlayPlugin.php
+++ b/src/PlugAndPlayPlugin.php
@@ -9,6 +9,7 @@ use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Dex\Composer\PlugAndPlay\Commands\DumpAutoloadCommand;
 use Dex\Composer\PlugAndPlay\Commands\InstallCommand;
+use Dex\Composer\PlugAndPlay\Commands\PlugAndPlayCommand;
 use Dex\Composer\PlugAndPlay\Commands\UpdateCommand;
 
 class PlugAndPlayPlugin implements Capable, CommandProvider, PluginInterface
@@ -35,6 +36,7 @@ class PlugAndPlayPlugin implements Capable, CommandProvider, PluginInterface
     public function getCommands()
     {
         return [
+            new PlugAndPlayCommand(),
             new InstallCommand(),
             new UpdateCommand(),
             new DumpAutoloadCommand(),

--- a/tests/Unit/ComposerCommandsTest.php
+++ b/tests/Unit/ComposerCommandsTest.php
@@ -14,6 +14,17 @@ class ComposerCommandsTest extends TestCase
      */
     protected $directory = __DIR__ . '/../Fixtures/Plugin/';
 
+    public function testPlugAndPlayCommand()
+    {
+        $application = new Application();
+        $input = new StringInput("plug-and-play --plug-and-play-pretend -d {$this->directory}");
+        $output = new BufferedOutput();
+
+        $application->doRun($input, $output);
+
+        $this->assertStringContainsString('You are using Composer Plug and Play Plugin.', $output->fetch());
+    }
+
     public function testPlugAndPlayInstallCommand()
     {
         $application = new Application();


### PR DESCRIPTION
Instead of the user deciding which command to use, `install` or `update`, the `composer plug-and-play` will decide.