### PR TITLE
Allow plugin in `composer.json` fixture to run tests

### DIFF
--- a/tests/Fixtures/Plugin/composer.json
+++ b/tests/Fixtures/Plugin/composer.json
@@ -2,6 +2,9 @@
     "require": {
         "dex/composer-plug-and-play": "*"
     },
+    "config": {
+        "allow-plugins": true
+    },
     "repositories": [
         {
             "type": "path",

--- a/tests/Unit/Composer/FactoryTest.php
+++ b/tests/Unit/Composer/FactoryTest.php
@@ -46,6 +46,9 @@ class FactoryTest extends TestCase
                 'dex/composer-plug-and-play' => '*',
                 'dex/fake' => '*',
             ],
+            'config' => [
+                'allow-plugins' => true,
+            ],
             'repositories' => [
                 [
                     'type' => 'path',


### PR DESCRIPTION
Some change in Composer froze test execution.