### PR TITLE
Add ability to ignore some plug and play packages

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -95,10 +95,16 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
             $localConfig = $this->loadJsonFile($io, $localConfig);
         }
 
+        $ignore = $localConfig['extra']['composer-plug-and-play']['ignore'] ?? [];
+
         $packages = glob(self::PATH);
 
         foreach ($packages as $package) {
             $data = $this->loadJsonFile($io, $package);
+
+            if (in_array($data['name'], $ignore)) {
+                continue;
+            }
 
             $localConfig['require'][$data['name']] = '*';
             $localConfig['repositories'][] = $this->createRepositoryItem($package);

--- a/tests/Fixtures/Plugin/composer.json
+++ b/tests/Fixtures/Plugin/composer.json
@@ -5,6 +5,13 @@
     "config": {
         "allow-plugins": true
     },
+    "extra": {
+        "composer-plug-and-play": {
+            "ignore": [
+                "dex/ignore"
+            ]
+        }
+    },
     "repositories": [
         {
             "type": "path",

--- a/tests/Fixtures/Plugin/packages/dex/ignore/composer.json
+++ b/tests/Fixtures/Plugin/packages/dex/ignore/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "dex/ignore"
+}

--- a/tests/Unit/Composer/FactoryTest.php
+++ b/tests/Unit/Composer/FactoryTest.php
@@ -49,6 +49,14 @@ class FactoryTest extends TestCase
             'config' => [
                 'allow-plugins' => true,
             ],
+            "extra" => [
+                'composer-plug-and-play' => [
+                    'ignore' => [
+                        "dex/ignore"
+
+                    ]
+                ]
+            ],
             'repositories' => [
                 [
                     'type' => 'path',


### PR DESCRIPTION
If you have a lot of packages in development, sometimes you may need one or two packages to be temporarily removed without removing their files.