### PR TITLE
Create `packages` directory if does not exists

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -58,6 +58,10 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
     {
         $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
 
+        if (is_dir(self::PACKAGES_PATH) === false) {
+            mkdir(self::PACKAGES_PATH);
+        }
+
         file_put_contents(self::FILENAME, $json);
     }
 

--- a/src/PlugAndPlayInterface.php
+++ b/src/PlugAndPlayInterface.php
@@ -8,5 +8,7 @@ interface PlugAndPlayInterface
 
     const PACKAGES_FILE = 'packages/composer.json';
 
+    const PACKAGES_PATH = 'packages';
+
     const PATH = 'packages/*/*/composer.json';
 }

--- a/tests/Unit/Commands/PlugAndPlayCommandTest.php
+++ b/tests/Unit/Commands/PlugAndPlayCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Dex\Composer\PlugAndPlay\Tests\Unit\Commands;
+
+use Dex\Composer\PlugAndPlay\Tests\Application;
+use Dex\Composer\PlugAndPlay\Tests\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class PlugAndPlayCommandTest extends TestCase
+{
+    protected $directory = __DIR__ . '/../../tmp';
+
+    protected function setUp(): void
+    {
+        $composer = json_encode([
+            'name' => 'dex/test',
+            'config' => [
+                'allow-plugins' => [
+                    'dex/composer-plug-and-play' => true,
+                    'dex/fake' => true,
+                ],
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        mkdir($this->directory);
+        file_put_contents($this->directory . '/composer.json', $composer);
+    }
+
+    protected function tearDown(): void
+    {
+        exec('rm -r ' . $this->directory);
+    }
+
+    public function testPackagesDirectoryIsCreated(): void
+    {
+        $application = new Application();
+        $input = new StringInput("plug-and-play -d {$this->directory}");
+        $output = new BufferedOutput();
+
+        $application->doRun($input, $output);
+
+        $this->assertDirectoryExists($this->directory);
+    }
+}


### PR DESCRIPTION
When running some plug and play command if the `packages` directory does not exist, an error will be thrown.