### PR TITLE
Create file if not exists

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -26,15 +26,13 @@ class AddCommand extends BaseCommand
     {
         $output->writeln('<info>You are using Composer Plug and Play Plugin.</info>');
 
-        if (file_exists(PlugAndPlayInterface::PACKAGES_FILE) === false) {
-            $output->writeln('The [' . PlugAndPlayInterface::PACKAGES_FILE . '] file not exists.');
+        $json = [];
 
-            return 1;
+        if (file_exists(PlugAndPlayInterface::PACKAGES_FILE)) {
+            $composer = file_get_contents(PlugAndPlayInterface::PACKAGES_FILE);
+
+            $json = json_decode($composer, true);
         }
-
-        $composer = file_get_contents(PlugAndPlayInterface::PACKAGES_FILE);
-
-        $json = json_decode($composer, true);
 
         $json['require'][$input->getArgument('package')] = $input->getArgument('version');
 

--- a/tests/Unit/Commands/AddCommandTest.php
+++ b/tests/Unit/Commands/AddCommandTest.php
@@ -72,12 +72,16 @@ class AddCommandTest extends CommandTestCase
         $this->assertJsonStringEqualsJsonFile($this->packagesFile(), $expected);
     }
 
-    public function testFileNotExists(): void
+    public function testMergeJsonFiles(): void
     {
-        $output = $this->runCommand('plug-and-play:add dex/extra');
+        $this->runCommand('plug-and-play:add dex/extra');
 
-        $message = 'The [' . PlugAndPlayInterface::PACKAGES_FILE . '] file not exists.';
+        $expected = $this->encodeContent([
+            'require' => [
+                'dex/extra' => '*',
+            ],
+        ]);
 
-        $this->assertStringContainsString($message, $output->fetch());
+        $this->assertJsonStringEqualsJsonFile($this->packagesFile(), $expected);
     }
 }


### PR DESCRIPTION
Instead of throw a error, create `composer.json` file.