### PR TITLE
Use `@dev` constraint for plugged packages

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -149,7 +149,7 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
 
             $plugged[] = $data['name'];
 
-            $localConfig['require'][$data['name']] = '*';
+            $localConfig['require'][$data['name']] = '@dev';
             $localConfig['repositories'][] = $this->createRepositoryItem($package);
         }
     }

--- a/tests/Fixtures/Plugin/packages/plug-and-play.json
+++ b/tests/Fixtures/Plugin/packages/plug-and-play.json
@@ -2,7 +2,7 @@
     "require": {
         "dex/composer-plug-and-play": "*",
         "composer/composer": "*",
-        "dex/fake": "*"
+        "dex/fake": "@dev"
     },
     "config": {
         "allow-plugins": true

--- a/tests/Unit/Composer/FactoryTest.php
+++ b/tests/Unit/Composer/FactoryTest.php
@@ -47,7 +47,7 @@ class FactoryTest extends TestCase
             'require' => [
                 'dex/composer-plug-and-play' => '*',
                 'composer/composer' => '*',
-                'dex/fake' => '*',
+                'dex/fake' => '@dev',
             ],
             'config' => [
                 'allow-plugins' => true,


### PR DESCRIPTION
When using wildcard `*` for plug and play package version and minimum stability equals stable in root `composer.json`, an error is thrown due to stability not matching. For this, `@dev` change the minimum stability to just the plug and play package.

See https://getcomposer.org/doc/articles/versions.md#stability-constraints.