### PR TITLE
Add a use case base for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /.build
 /vendor
-composer.lock
+/composer.lock

--- a/tests/UseCase.php
+++ b/tests/UseCase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Dex\Composer\PlugAndPlay\Tests;
+
+use Composer\IO\IOInterface;
+use Dex\Composer\PlugAndPlay\Composer\Factory;
+use Dex\Composer\PlugAndPlay\PlugAndPlayInterface;
+
+abstract class UseCase extends TestCase
+{
+    protected string $cwd;
+    protected Factory $factory;
+
+    abstract protected function path(): string;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cwd = getcwd();
+
+        chdir($this->path());
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Factory::restart();
+
+        chdir($this->cwd);
+    }
+
+    protected function getPackageFilename(): string
+    {
+        return $this->path() . PlugAndPlayInterface::FILENAME;
+    }
+
+    protected function factory(): Factory
+    {
+        $io = $this->createMock(IOInterface::class);
+
+        $factory = new Factory();
+
+        $factory->createComposer(io: $io, cwd: $this->path());
+
+        return $factory;
+    }
+
+    protected function assertGeneratedJsonEquals(array $data): void
+    {
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
+
+        $this->assertStringEqualsFile($this->getPackageFilename(), $json);
+    }
+}


### PR DESCRIPTION
Add a use case base for testing that check if generated JSON is equal to expected.

Example for a test:

```php
namespace Dex\Composer\PlugAndPlay\Tests\UseCase;

use Dex\Composer\PlugAndPlay\Tests\UseCase;

class UseCaseTest extends UseCase
{
    protected function path(): string
    {
        return __DIR__ . '/../../fixtures/path/' ;
    }

    public function testFactory(): void
    {
        $this->factory();

        $this->assertGeneratedJsonEquals([
            // data within generated JSON
        ]);
    }
}
```