### PR TITLE
Avoid break json schema

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -134,6 +134,17 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
             $plugged[] = $package;
         }
 
+        # TODO improve next lines
+        if (isset($packagesConfig['minimum-stability'])) {
+            $localConfig['minimum-stability'] = $packagesConfig['minimum-stability'];
+            unset($packagesConfig['minimum-stability']);
+        }
+
+        if (isset($packagesConfig['prefer-stable'])) {
+            $localConfig['prefer-stable'] = $packagesConfig['prefer-stable'];
+            unset($packagesConfig['prefer-stable']);
+        }
+
         $localConfig = array_merge_recursive($localConfig, $packagesConfig);
     }
 


### PR DESCRIPTION
Avoid break json schema when merging root `composer.json` with keys `prefer-stable` and `minimum-stability`.

Added TODO to refactor in future.