### PR TITLE
Fix merge behavior and method signature compatibility with Composer commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - 2.4
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install PHP
       uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.composer-version }}-${{ hashFiles('**/composer.lock') }}

--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -64,7 +64,7 @@ trait ComposerCreator
      * @param bool|null $disableScripts If null, reads --no-scripts as default
      * @throws \Dex\Composer\PlugAndPlay\Exceptions\ComposerCreationException
      */
-    public function requireComposer(bool $disablePlugins = null, bool $disableScripts = null): Composer
+    public function requireComposer(?bool $disablePlugins = false, ?bool $disableScripts = false): Composer
     {
         // It's needed that Composer will be reseted because
         // Application::getPluginCommands() creates a Composer instance without
@@ -75,8 +75,8 @@ trait ComposerCreator
         return Factory::create(
             $this->getApplication()->getIO(),
             null,
-            $disablePlugins,
-            $disableScripts
+            $disablePlugins ?? false,
+            $disableScripts ?? false
         );
     }
 

--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -72,7 +72,12 @@ trait ComposerCreator
 
         $this->resetComposer();
 
-        return Factory::create($this->getApplication()->getIO());
+        return Factory::create(
+            $this->getApplication()->getIO(),
+            null,
+            $disablePlugins,
+            $disableScripts
+        );
     }
 
     /**

--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -6,7 +6,7 @@ use Composer\Composer;
 use Composer\Console\Application;
 use Composer\Json\JsonValidationException;
 use Dex\Composer\PlugAndPlay\Composer\Factory;
-use RuntimeException;
+use Dex\Composer\PlugAndPlay\Exceptions\ComposerCreationException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,7 +21,7 @@ trait ComposerCreator
      * @param bool      $required
      * @param bool|null $disablePlugins
      *
-     * @throws JsonValidationException|RuntimeException
+     * @throws JsonValidationException|ComposerCreationException
      *
      * @return Composer
      */
@@ -35,7 +35,7 @@ trait ComposerCreator
             if ($application instanceof Application) {
                 $composer = Factory::create($application->getIO(), null, $disablePlugins);
             } elseif ($required) {
-                throw new RuntimeException(
+                throw new ComposerCreationException(
                     'Could not create a Composer\Composer instance, you must inject ' .
                     'one if this command is not used with a Composer\Console\Application instance'
                 );
@@ -62,7 +62,7 @@ trait ComposerCreator
      *
      * @param bool|null $disablePlugins If null, reads --no-plugins as default
      * @param bool|null $disableScripts If null, reads --no-scripts as default
-     * @throws \RuntimeException
+     * @throws \Dex\Composer\PlugAndPlay\Exceptions\ComposerCreationException
      */
     public function requireComposer(bool $disablePlugins = null, bool $disableScripts = null): Composer
     {

--- a/src/Commands/ComposerCreator.php
+++ b/src/Commands/ComposerCreator.php
@@ -83,7 +83,7 @@ trait ComposerCreator
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $isTheCommand = $input->getFirstArgument() === $this->getName();
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -125,7 +125,7 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
                 $plugged[] = $package;
             }
 
-            $localConfig = array_merge_recursive($localConfig, $packagesConfig);
+            $localConfig = $this->mergeRecursiveDistinct($localConfig, $packagesConfig);
         }
 
         $ignore = $localConfig['extra']['composer-plug-and-play']['ignore'] ?? [];
@@ -172,5 +172,27 @@ class Factory extends ComposerFactory implements PlugAndPlayInterface
         }
 
         return parent::createComposer($io, self::FILENAME, $disablePlugins, $cwd, $fullLoad, $disableScripts);
+    }
+
+    /**
+     * Performs a recursive merge of two arrays,
+     * but replaces values instead of merging duplicate entries into arrays.
+     *
+     * @param array<int|string, mixed> $array1
+     * @param array<int|string, mixed> $array2
+     * @return array<int|string, mixed>
+     */
+    private function mergeRecursiveDistinct(array $array1, array &$array2): array
+    {
+        $merged = $array1;
+        foreach ($array2 as $key => &$value) {
+            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = $this->mergeRecursiveDistinct($merged[$key], $value);
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
     }
 }

--- a/src/Exceptions/ComposerCreationException.php
+++ b/src/Exceptions/ComposerCreationException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Dex\Composer\PlugAndPlay\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when a Composer instance cannot be created.
+ */
+class ComposerCreationException extends RuntimeException
+{
+    /**
+     * Create a new ComposerCreationException instance.
+     *
+     * @param string $message
+     * @param int $code
+     * @param \Throwable|null $previous
+     */
+    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Duplicates plug-and-play.json configs

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c032f0e0-32c5-416e-a0e4-df38521d5434" />

Erro line: 
<img width="888" alt="image" src="https://github.com/user-attachments/assets/9555b818-c428-440b-a507-9fcff39755ec" />

Error return interface:

```sh
PHP Fatal error:  Declaration of Dex\Composer\PlugAndPlay\Commands\ComposerCreator::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Composer\Command\InstallCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /private/var/www/ecidade/vendor/dex/composer-plug-and-play/src/Commands/InstallCommand.php on line 86

Fatal error: Declaration of Dex\Composer\PlugAndPlay\Commands\ComposerCreator::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Composer\Command\InstallCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /private/var/www/ecidade/vendor/dex/composer-plug-and-play/src/Commands/InstallCommand.php on line 86
```

Local Environment
```sh
Composer version 2.8.3 2024-11-17 13:13:04
PHP version 7.4.33 (/opt/homebrew/Cellar/php@7.4/7.4.33_9/bin/php)
```