### PR TITLE
Uses default `run` command to execute scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,9 @@
         "test": "vendor/bin/pest"
     },
     "scripts-descriptions": {
+        "coverage": "Runs coverage",
         "format": "Format code",
-        "test": "Runs package tests",
-        "test:coverage": "Runs coverage",
-        "test:coverage:open": "Opens coverage report"
+        "test": "Runs tests"
     },
     "config": {
         "allow-plugins": {

--- a/fixtures/run-command/composer.json
+++ b/fixtures/run-command/composer.json
@@ -1,0 +1,8 @@
+{
+    "config": {
+        "allow-plugins": true
+    },
+    "scripts": {
+        "root-script": "echo root > /dev/null"
+    }
+}

--- a/fixtures/run-command/packages/composer.json
+++ b/fixtures/run-command/packages/composer.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "pp-script": "echo pp > /dev/null",
+        "root-script": "echo pp > /dev/null"
+    }
+}

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -4,6 +4,9 @@ namespace Dex\Composer\PlugAndPlay\Commands;
 
 use Composer\Command\RunScriptCommand as ComposerRunCommand;
 
+/**
+ * @deprecated
+ */
 class RunCommand extends ComposerRunCommand
 {
     use ComposerCreator;

--- a/src/PlugAndPlayPlugin.php
+++ b/src/PlugAndPlayPlugin.php
@@ -20,7 +20,9 @@ class PlugAndPlayPlugin implements Capable, CommandProvider, PluginInterface
 {
     public function activate(Composer $composer, IOInterface $io): void
     {
-        // Do nothing..
+        if (file_exists(PlugAndPlayInterface::PACKAGES_FILE)) {
+            $this->mergeScripts($composer);
+        }
     }
 
     public function deactivate(Composer $composer, IOInterface $io): void
@@ -52,5 +54,25 @@ class PlugAndPlayPlugin implements Capable, CommandProvider, PluginInterface
             new ResetCommand(),
             new RunCommand(),
         ];
+    }
+
+    private function mergeScripts(Composer $composer): void
+    {
+        $file = file_get_contents(PlugAndPlayInterface::PACKAGES_FILE);
+        $config = json_decode($file, true) ?? [];
+        $scripts = $config['scripts'] ?? [];
+
+        if (empty($scripts)) {
+            return;
+        }
+
+        $rootPackage = $composer->getPackage();
+        $existingScripts = $rootPackage->getScripts();
+
+        foreach ($scripts as $name => $script) {
+            $existingScripts[$name] = (array) $script;
+        }
+
+        $rootPackage->setScripts($existingScripts);
     }
 }

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -1,0 +1,20 @@
+<?php
+
+beforeEach()
+    ->fixtures('run-command')
+    ->prepare();
+
+afterEach()
+    ->cleanup();
+
+test('scripts from packages/composer.json are available to composer run', function () {
+    $this->runCommand('run pp-script');
+
+    $this->assertStringNotContainsString('is not defined', $this->output);
+});
+
+test('scripts from packages/composer.json override root scripts', function () {
+    $this->runCommand('run root-script');
+
+    $this->assertStringNotContainsString('is not defined', $this->output);
+});

--- a/tests/PlugAndPlayPluginTest.php
+++ b/tests/PlugAndPlayPluginTest.php
@@ -6,6 +6,7 @@ use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\BufferIO;
 use Composer\Package\Locker;
 use Composer\Package\Package;
+use Composer\Package\RootPackageInterface;
 use Composer\Plugin\Capability\CommandProvider;
 use Composer\Plugin\PluginManager;
 use Dex\Composer\PlugAndPlay\PlugAndPlayPlugin;
@@ -14,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 beforeEach(function () {
     $locker = $this->createMock(Locker::class);
     $dispatcher = $this->createMock(EventDispatcher::class);
+    $package = $this->createMock(RootPackageInterface::class);
 
     $config = new Config();
     $config->merge([
@@ -26,6 +28,7 @@ beforeEach(function () {
     $this->composer->setConfig($config);
     $this->composer->setLocker($locker);
     $this->composer->setEventDispatcher($dispatcher);
+    $this->composer->setPackage($package);
 
     $this->io = new BufferIO('', OutputInterface::VERBOSITY_DEBUG);
     $this->pm = new PluginManager($this->io, $this->composer);


### PR DESCRIPTION
Instead of run `composer plug-and-play:run` to execute script from `packages/composer.json`, uses the original `composer run` command.
